### PR TITLE
feat(babel): expose CSS extraction from AST logic (#737)

### DIFF
--- a/packages/babel/src/index.ts
+++ b/packages/babel/src/index.ts
@@ -15,7 +15,11 @@ export { default as JSXElement } from './evaluators/visitors/JSXElement';
 export { default as ProcessCSS } from './evaluators/visitors/ProcessCSS';
 export { default as ProcessStyled } from './evaluators/visitors/ProcessStyled';
 export { default as Module } from './module';
-export { default as transform } from './transform';
+export {
+  default as transform,
+  extractCssFromAst,
+  shouldTransformCode,
+} from './transform';
 export * from './types';
 export type { PluginOptions } from './utils/loadOptions';
 export { default as isNode } from './utils/isNode';


### PR DESCRIPTION
- Moved logic for extracting CSS from the AST into
  a `extractCssFromAst()` function and exported it from the
  `@linaria/babel-preset` package

<!--
Thanks for submitting a pull request!
Please provide enough information so that others can review your pull request.
Motivation and Test plan are mandatory.
-->

## Motivation

<!--
If pull request address existing issues, link the issues, thats all.

If issue for this soled problem does not exist,
please share your motivation and describe the problem.
We may ask you to open issue to discuss the problem first.
-->

## Summary

<!--
Explain how your implementation works and your thoughts behind the solution.
It will help maintainers to review your PR.
You can skip it if PR is trivial.
-->

## Test plan

<!--
Demonstrate the code is solid.
Example: The exact commands you ran and their output.
Write down steps on how maintainers can test your PR.
-->
